### PR TITLE
[K8s] Send Limited Batches

### DIFF
--- a/k8s/autoops_agent_deployment.yaml
+++ b/k8s/autoops_agent_deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - args:
             - '--config'
             - otel_samples/autoops_es.yml
+            - '--set'
+            - 'exporters::otlphttp::sending_queue::batch::max_size=4194304' # 4 MiB (Remove after 9.1.5+)
+            - '--set'
+            - 'exporters::otlphttp::sending_queue::batch::sizer=bytes'
           env:
             - name: AUTOOPS_TOKEN
               valueFrom:


### PR DESCRIPTION
Added configuration options for OTLP HTTP exporter so that batches are not rejected.

This can be removed after 9.1.5 (after https://github.com/elastic/elastic-agent/pull/10126 is exposed by default).