### PR TITLE
Update README to specify version must be 9.1.4 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Use the `install_autoops.sh` script in order to install a new agent on your Linu
   --temp-resource-id "<Provided by AutoOps installation wizard>" \
   --es-endpoint "<your-es-url>" \
   --es-username "<your-es-user>" \
-  --es-password "<your-es-pass>" \
   --es-password "<your-es-pass>"
 ```
 
@@ -93,6 +92,5 @@ Use the `install_autoops.sh` script in order to install a new agent on your Linu
   --ccm-api-url "<Provided by AutoOps installation wizard if needed>" \
   --temp-resource-id "<Provided by AutoOps installation wizard>" \
   --es-endpoint "<your-es-url>" \
-  --es-api-key "<your-es-api-key>" \
   --es-api-key "<your-es-api-key>"
 ```


### PR DESCRIPTION
Clarified version requirement for Elastic Agent.
I've seen two cases recently where a user tried to force this to a 8.x version and it failed because the AutoOps module doesn't exist in 8.x.

@pickypg not 100% sure about 9.0.4 as the minimum version. Feel free to reword 