### PR TITLE
[Diagnostic] Add better formatting and messaging

### DIFF
--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -567,7 +567,10 @@ print_summary() {
   echo ""
 
   if [[ $CHECKS_FAILED -gt 0 ]]; then
-    print_error "Connectivity issues detected. AutoOps Agent will not function. Review troubleshooting guide and address issues before running the agent."
+    print_error "Connectivity issues detected. AutoOps Agent will not function."
+    echo ""
+    echo "  Review the troubleshooting guide and address issues before running the agent:"
+    echo "  https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting"
     return 1
   elif [[ $CHECKS_SKIPPED -gt 0 ]]; then
     print_success "Elastic Cloud connectivity checks passed."

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -735,6 +735,8 @@ test_summary_some_fail() {
 
   assert_exit_code 1 "$exit_code"
   assert_output_contains "❌ FAIL:    Connectivity issues detected. AutoOps Agent will not function." "$output"
+  assert_output_contains "troubleshooting guide" "$output"
+  assert_output_contains "elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting" "$output"
 }
 
 test_summary_skipped() {


### PR DESCRIPTION
This massages the output from the script based on internal suggestions. It also adds emojis to attract the eye to success, failures, warnings, and info (note the warning and info emojis have a variable space as part of them, so if you copy the text from the terminal, you _may_ end up with two spaces).

Successful checks example (`AUTOOPS_ES_URL=http://localhost:9200 ./tools/check_connectivity.sh`):

```
========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    No proxy detected; using direct connection.

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ✅ SUCCESS: Reachable. Can register to Elastic Cloud.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Elasticsearch ---
  ℹ️ INFO:    URL: http://localhost:9200
  ℹ️ INFO:    Auth: none
  ℹ️ INFO:    Checking connectivity to http://localhost:9200/...
  ✅ SUCCESS: Connected successfully (HTTP 200)
  ℹ️ INFO:    Cluster: docker-cluster
  ℹ️ INFO:    Version: 8.19.3
  ℹ️ INFO:    Checking license status at http://localhost:9200/_license...
  ✅ SUCCESS: License: active (basic: 2afedca3-b34d-43d0-b7c0-5f61ddbdbc58)

--- Summary ---

  Passed:  3
  Failed:  0
  Skipped: 0

  ✅ SUCCESS: All checks passed. The environment is ready to use AutoOps.
```

Failure scenario (`HTTPS_PROXY=https://invalid-proxy-url ./tools/check_connectivity.sh`):

```
========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    HTTPS_PROXY=https://invalid-proxy-url

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ❌ FAIL:    Could not resolve proxy host.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ❌ FAIL:    Could not resolve proxy host.

--- Elasticsearch ---
  ⚠️ SKIPPED: Elasticsearch check skipped (AUTOOPS_ES_URL not set). Set AUTOOPS_ES_URL to enable connectivity testing

--- Summary ---

  Passed:  0
  Failed:  2
  Skipped: 1

  ❌ FAIL:    Connectivity issues detected. AutoOps Agent will not function. Review troubleshooting guide and address issues before running the agent.

  Review the troubleshooting guide and address issues before running the agent:
  https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting
```

Skipping ES checks (`./tools/check_connectivity.sh`):

```
========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    No proxy detected; using direct connection.

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ✅ SUCCESS: Reachable. Can register to Elastic Cloud.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Elasticsearch ---
  ⚠️ SKIPPED: Elasticsearch check skipped (AUTOOPS_ES_URL not set). Set AUTOOPS_ES_URL to enable connectivity testing

--- Summary ---

  Passed:  2
  Failed:  0
  Skipped: 1

  ✅ SUCCESS: Elastic Cloud connectivity checks passed.
  ⚠️ SKIPPED: The Elasticsearch environment was not checked.
```