### PR TITLE
[Diagnostic] Run Elasticsearch lookup first and register the Cluster if possible

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,10 @@
 # This file is used by .github/workflows/pr-labeler.yml and its format depends on the version used there
 # https://github.com/actions/labeler#pull-request-labeler
 
+':README':
+  - changed-files:
+    - any-glob-to-any-file: README.md
+
 ':diagnostics':
   - changed-files:
     - any-glob-to-any-file: tools/**

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Use the `install_autoops.sh` script in order to install a new agent on your Linu
 The `tools/check_connectivity.sh` script verifies network connectivity and configuration before or after installation. It checks:
 
 1. **Proxy Configuration** - Detects if HTTP_PROXY, HTTPS_PROXY, NO_PROXY, or other proxy variables are set
-2. **Cloud API Connectivity** - Tests connectivity to the Elastic Cloud Connected Mode API
-3. **OTel Endpoint** - Tests connectivity to the OpenTelemetry endpoint
-4. **Elasticsearch** - Tests connectivity to your Elasticsearch cluster with authentication
+2. **Elasticsearch** - Tests connectivity to your Elasticsearch cluster with authentication
+3. **Cloud API Connectivity** - Tests connectivity to the Elastic Cloud Connected Mode API
+4. **OTel Endpoint** - Tests connectivity to the OpenTelemetry endpoint
 
 ### Usage
 
@@ -116,13 +116,14 @@ The `tools/check_connectivity.sh` script verifies network connectivity and confi
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ELASTIC_CLOUD_CONNECTED_MODE_API_URL` | No | `https://api.elastic-cloud.com` | Cloud API URL |
-| `AUTOOPS_OTEL_URL` | No | `https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud` | OTel endpoint URL |
 | `AUTOOPS_ES_URL` | No | (skipped if unset) | Elasticsearch URL |
 | `AUTOOPS_ES_USERNAME` | No | - | Elasticsearch username (for Basic auth) |
 | `AUTOOPS_ES_PASSWORD` | No | - | Elasticsearch password (for Basic auth) |
 | `AUTOOPS_ES_API_KEY` | No | - | Elasticsearch API key (for ApiKey auth) |
 | `AUTOOPS_ES_CA` | No | - | Path to CA certificate file |
+| `AUTOOPS_OTEL_URL` | No | `https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud` | OTel endpoint URL |
+| `ELASTIC_CLOUD_CONNECTED_MODE_API_URL` | No | `https://api.elastic-cloud.com` | Cloud API URL |
+| `ELASTIC_CLOUD_CONNECTED_MODE_API_KEY` | No | - | Cloud API key; when set alongside `AUTOOPS_ES_URL`, registers the cluster with Elastic Cloud |
 
 ### Example with Elasticsearch
 
@@ -134,5 +135,8 @@ AUTOOPS_ES_API_KEY="your-api-key" \
 
 ### Exit Codes
 
-- `0` - All checks passed
-- `1` - One or more checks failed
+| Code | Description |
+|------|-------------|
+| `0` | All checks passed |
+| `1` | One or more checks failed |
+| `2` | One or more checks were skipped (e.g. `AUTOOPS_ES_URL` not set) |

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -532,9 +532,9 @@ check_cloud_api() {
     # Payload was sent — validate registration succeeded
     if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
       if [[ "$DEBUG" == "true" ]]; then
-        print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
+        print_success "Reachable. The cluster has been registered to Elastic Cloud. (HTTP $http_code)"
       else
-        print_success "Reachable. Can register to Elastic Cloud."
+        print_success "Reachable. The cluster has been registered to Elastic Cloud."
       fi
     else
       local error_detail=""

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -238,153 +238,7 @@ check_proxy() {
 }
 
 # ---------------------------
-# Check 2a: Cloud API Connectivity
-# ---------------------------
-
-check_cloud_api() {
-  print_section "Elastic Cloud Connected Mode API"
-
-  local base_url="${ELASTIC_CLOUD_CONNECTED_MODE_API_URL:-}"
-  local using_default=""
-  if [[ -z "$base_url" ]]; then
-    base_url="https://api.elastic-cloud.com"
-    using_default=" (default)"
-  fi
-  local check_url="${base_url}/api/v1/cloud-connected/clusters"
-
-  print_info "URL: ${base_url}${using_default}"
-  print_check "connectivity to ${check_url}"
-
-  local api_key="${ELASTIC_CLOUD_CONNECTED_MODE_API_KEY:-}"
-  local http_code
-  local curl_exit
-
-  if [[ -n "$api_key" && -n "$ES_CLUSTER_NAME" ]]; then
-    local payload
-    payload=$(printf '{"self_managed_cluster":{"id":"%s","name":"%s","version":"%s"},"license":{"uid":"%s","type":"%s"}}' \
-      "$ES_CLUSTER_ID" "$ES_CLUSTER_NAME" "$ES_VERSION" "$ES_LICENSE_UID" "$ES_LICENSE_TYPE")
-
-    http_code=$(curl -sS -X POST \
-      -H "Content-Type: application/json" \
-      -H "Authorization: ApiKey ${api_key}" \
-      -d "$payload" \
-      -w "%{http_code}" \
-      -o "${RESPONSE_FILE}" \
-      --connect-timeout 10 \
-      --max-time 30 \
-      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
-  else
-    http_code=$(curl -sS -X POST \
-      -H "Content-Length: 0" \
-      -w "%{http_code}" \
-      -o /dev/null \
-      --connect-timeout 10 \
-      --max-time 30 \
-      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
-  fi
-
-  curl_exit=${curl_exit:-0}
-
-  if [[ $curl_exit -ne 0 ]]; then
-    local error_msg
-    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)")
-    print_error "$error_msg"
-    if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
-      print_warning "A proxy is configured — this may be causing the connection failure"
-    fi
-    ((CHECKS_FAILED++))
-    return 1
-  fi
-
-  if [[ -n "$api_key" && -n "$ES_CLUSTER_NAME" ]]; then
-    # Payload was sent — validate registration succeeded
-    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
-      if [[ "$DEBUG" == "true" ]]; then
-        print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
-      else
-        print_success "Reachable. Can register to Elastic Cloud."
-      fi
-    else
-      local error_detail=""
-      if [[ -f "${RESPONSE_FILE}" ]]; then
-        local error_code error_message
-        error_code=$(grep -o '"code"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
-        error_message=$(grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
-        if [[ -n "$error_code" && -n "$error_message" ]]; then
-          error_detail=" ($error_code: $error_message)"
-        elif [[ -n "$error_message" ]]; then
-          error_detail=" ($error_message)"
-        fi
-      fi
-      print_error "Registration failed (HTTP $http_code)${error_detail}."
-      ((CHECKS_FAILED++))
-      return 1
-    fi
-  else
-    # Any HTTP response means connectivity works (even 4xx/5xx)
-    if [[ "$DEBUG" == "true" ]]; then
-      print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
-    else
-      print_success "Reachable. Can register to Elastic Cloud."
-    fi
-  fi
-  ((CHECKS_PASSED++))
-  return 0
-}
-
-# ---------------------------
-# Check 2b: OTel Endpoint
-# ---------------------------
-
-check_otel() {
-  print_section "OTel Endpoint"
-
-  local otel_url="${AUTOOPS_OTEL_URL:-}"
-  local using_default=""
-  if [[ -z "$otel_url" ]]; then
-    otel_url="https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud"
-    using_default=" (default)"
-  fi
-  local check_url="${otel_url}/v1/logs"
-
-  print_info "URL: ${otel_url}${using_default}"
-  print_check "connectivity to ${check_url}"
-
-  local http_code
-  local curl_exit
-
-  http_code=$(curl -sS -X POST \
-    -H "Content-Length: 0" \
-    -w "%{http_code}" \
-    -o /dev/null \
-    --connect-timeout 10 \
-    --max-time 30 \
-    "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
-
-  curl_exit=${curl_exit:-0}
-
-  if [[ $curl_exit -ne 0 ]]; then
-    local error_msg
-    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)")
-    print_error "$error_msg"
-    if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
-      print_warning "A proxy is configured — this may be causing the connection failure"
-    fi
-    ((CHECKS_FAILED++))
-    return 1
-  fi
-
-  if [[ "$DEBUG" == "true" ]]; then
-    print_success "Reachable. Can ship metrics to Elastic Cloud. (HTTP $http_code)"
-  else
-    print_success "Reachable. Can ship metrics to Elastic Cloud."
-  fi
-  ((CHECKS_PASSED++))
-  return 0
-}
-
-# ---------------------------
-# Check 3: Elasticsearch
+# Check 2: Elasticsearch
 # ---------------------------
 
 check_elasticsearch() {
@@ -613,6 +467,152 @@ check_elasticsearch() {
       return 0
       ;;
   esac
+}
+
+# ---------------------------
+# Check 3a: Cloud API Connectivity
+# ---------------------------
+
+check_cloud_api() {
+  print_section "Elastic Cloud Connected Mode API"
+
+  local base_url="${ELASTIC_CLOUD_CONNECTED_MODE_API_URL:-}"
+  local using_default=""
+  if [[ -z "$base_url" ]]; then
+    base_url="https://api.elastic-cloud.com"
+    using_default=" (default)"
+  fi
+  local check_url="${base_url}/api/v1/cloud-connected/clusters"
+
+  print_info "URL: ${base_url}${using_default}"
+  print_check "connectivity to ${check_url}"
+
+  local api_key="${ELASTIC_CLOUD_CONNECTED_MODE_API_KEY:-}"
+  local http_code
+  local curl_exit
+
+  if [[ -n "$api_key" && -n "$ES_CLUSTER_NAME" ]]; then
+    local payload
+    payload=$(printf '{"self_managed_cluster":{"id":"%s","name":"%s","version":"%s"},"license":{"uid":"%s","type":"%s"}}' \
+      "$ES_CLUSTER_ID" "$ES_CLUSTER_NAME" "$ES_VERSION" "$ES_LICENSE_UID" "$ES_LICENSE_TYPE")
+
+    http_code=$(curl -sS -X POST \
+      -H "Content-Type: application/json" \
+      -H "Authorization: ApiKey ${api_key}" \
+      -d "$payload" \
+      -w "%{http_code}" \
+      -o "${RESPONSE_FILE}" \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  else
+    http_code=$(curl -sS -X POST \
+      -H "Content-Length: 0" \
+      -w "%{http_code}" \
+      -o /dev/null \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  fi
+
+  curl_exit=${curl_exit:-0}
+
+  if [[ $curl_exit -ne 0 ]]; then
+    local error_msg
+    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)")
+    print_error "$error_msg"
+    if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
+      print_warning "A proxy is configured — this may be causing the connection failure"
+    fi
+    ((CHECKS_FAILED++))
+    return 1
+  fi
+
+  if [[ -n "$api_key" && -n "$ES_CLUSTER_NAME" ]]; then
+    # Payload was sent — validate registration succeeded
+    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+      if [[ "$DEBUG" == "true" ]]; then
+        print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
+      else
+        print_success "Reachable. Can register to Elastic Cloud."
+      fi
+    else
+      local error_detail=""
+      if [[ -f "${RESPONSE_FILE}" ]]; then
+        local error_code error_message
+        error_code=$(grep -o '"code"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
+        error_message=$(grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
+        if [[ -n "$error_code" && -n "$error_message" ]]; then
+          error_detail=" ($error_code: $error_message)"
+        elif [[ -n "$error_message" ]]; then
+          error_detail=" ($error_message)"
+        fi
+      fi
+      print_error "Registration failed (HTTP $http_code)${error_detail}."
+      ((CHECKS_FAILED++))
+      return 1
+    fi
+  else
+    # Any HTTP response means connectivity works (even 4xx/5xx)
+    if [[ "$DEBUG" == "true" ]]; then
+      print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
+    else
+      print_success "Reachable. Can register to Elastic Cloud."
+    fi
+  fi
+  ((CHECKS_PASSED++))
+  return 0
+}
+
+# ---------------------------
+# Check 3b: OTel Endpoint
+# ---------------------------
+
+check_otel() {
+  print_section "OTel Endpoint"
+
+  local otel_url="${AUTOOPS_OTEL_URL:-}"
+  local using_default=""
+  if [[ -z "$otel_url" ]]; then
+    otel_url="https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud"
+    using_default=" (default)"
+  fi
+  local check_url="${otel_url}/v1/logs"
+
+  print_info "URL: ${otel_url}${using_default}"
+  print_check "connectivity to ${check_url}"
+
+  local http_code
+  local curl_exit
+
+  http_code=$(curl -sS -X POST \
+    -H "Content-Length: 0" \
+    -w "%{http_code}" \
+    -o /dev/null \
+    --connect-timeout 10 \
+    --max-time 30 \
+    "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+
+  curl_exit=${curl_exit:-0}
+
+  if [[ $curl_exit -ne 0 ]]; then
+    local error_msg
+    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)")
+    print_error "$error_msg"
+    if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
+      print_warning "A proxy is configured — this may be causing the connection failure"
+    fi
+    ((CHECKS_FAILED++))
+    return 1
+  fi
+
+  if [[ "$DEBUG" == "true" ]]; then
+    print_success "Reachable. Can ship metrics to Elastic Cloud. (HTTP $http_code)"
+  else
+    print_success "Reachable. Can ship metrics to Elastic Cloud."
+  fi
+  ((CHECKS_PASSED++))
+  return 0
 }
 
 # ---------------------------

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -596,9 +596,9 @@ main() {
   print_header
 
   check_proxy
+  check_elasticsearch
   check_cloud_api
   check_otel
-  check_elasticsearch
 
   print_summary
   exit $?

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -539,7 +539,7 @@ check_cloud_api() {
 
   if [[ $curl_exit -ne 0 ]]; then
     local error_msg
-    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)")
+    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)" "$check_url")
     print_error "$error_msg"
     if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
       print_warning "A proxy is configured — this may be causing the connection failure"
@@ -617,7 +617,7 @@ check_otel() {
 
   if [[ $curl_exit -ne 0 ]]; then
     local error_msg
-    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)")
+    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)" "$check_url")
     print_error "$error_msg"
     if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
       print_warning "A proxy is configured — this may be causing the connection failure"

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -296,11 +296,26 @@ check_cloud_api() {
     return 1
   fi
 
-  # Any HTTP response means connectivity works (even 4xx/5xx)
-  if [[ "$DEBUG" == "true" ]]; then
-    print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
+  if [[ -n "$api_key" && -n "$ES_CLUSTER_NAME" ]]; then
+    # Payload was sent — validate registration succeeded
+    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+      if [[ "$DEBUG" == "true" ]]; then
+        print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
+      else
+        print_success "Reachable. Can register to Elastic Cloud."
+      fi
+    else
+      print_error "Registration failed (HTTP $http_code)."
+      ((CHECKS_FAILED++))
+      return 1
+    fi
   else
-    print_success "Reachable. Can register to Elastic Cloud."
+    # Any HTTP response means connectivity works (even 4xx/5xx)
+    if [[ "$DEBUG" == "true" ]]; then
+      print_success "Reachable. Can register to Elastic Cloud. (HTTP $http_code)"
+    else
+      print_success "Reachable. Can register to Elastic Cloud."
+    fi
   fi
   ((CHECKS_PASSED++))
   return 0

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -269,7 +269,7 @@ check_cloud_api() {
       -H "Authorization: ApiKey ${api_key}" \
       -d "$payload" \
       -w "%{http_code}" \
-      -o /dev/null \
+      -o "${RESPONSE_FILE}" \
       --connect-timeout 10 \
       --max-time 30 \
       "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
@@ -305,7 +305,18 @@ check_cloud_api() {
         print_success "Reachable. Can register to Elastic Cloud."
       fi
     else
-      print_error "Registration failed (HTTP $http_code)."
+      local error_detail=""
+      if [[ -f "${RESPONSE_FILE}" ]]; then
+        local error_code error_message
+        error_code=$(grep -o '"code"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
+        error_message=$(grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
+        if [[ -n "$error_code" && -n "$error_message" ]]; then
+          error_detail=" ($error_code: $error_message)"
+        elif [[ -n "$error_message" ]]; then
+          error_detail=" ($error_message)"
+        fi
+      fi
+      print_error "Registration failed (HTTP $http_code)${error_detail}."
       ((CHECKS_FAILED++))
       return 1
     fi

--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -120,6 +120,12 @@ CHECKS_SKIPPED=0
 CHECKS_WARNED=0
 PROXY_CONFIGURED=false
 
+ES_CLUSTER_ID=""
+ES_CLUSTER_NAME=""
+ES_VERSION=""
+ES_LICENSE_UID=""
+ES_LICENSE_TYPE=""
+
 # ---------------------------
 # Version comparison
 # ---------------------------
@@ -249,16 +255,33 @@ check_cloud_api() {
   print_info "URL: ${base_url}${using_default}"
   print_check "connectivity to ${check_url}"
 
+  local api_key="${ELASTIC_CLOUD_CONNECTED_MODE_API_KEY:-}"
   local http_code
   local curl_exit
 
-  http_code=$(curl -sS -X POST \
-    -H "Content-Length: 0" \
-    -w "%{http_code}" \
-    -o /dev/null \
-    --connect-timeout 10 \
-    --max-time 30 \
-    "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  if [[ -n "$api_key" && -n "$ES_CLUSTER_NAME" ]]; then
+    local payload
+    payload=$(printf '{"self_managed_cluster":{"id":"%s","name":"%s","version":"%s"},"license":{"uid":"%s","type":"%s"}}' \
+      "$ES_CLUSTER_ID" "$ES_CLUSTER_NAME" "$ES_VERSION" "$ES_LICENSE_UID" "$ES_LICENSE_TYPE")
+
+    http_code=$(curl -sS -X POST \
+      -H "Content-Type: application/json" \
+      -H "Authorization: ApiKey ${api_key}" \
+      -d "$payload" \
+      -w "%{http_code}" \
+      -o /dev/null \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  else
+    http_code=$(curl -sS -X POST \
+      -H "Content-Length: 0" \
+      -w "%{http_code}" \
+      -o /dev/null \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  fi
 
   curl_exit=${curl_exit:-0}
 
@@ -447,12 +470,18 @@ check_elasticsearch() {
       # Try to extract cluster info from response
       if [[ -f "${RESPONSE_FILE}" ]]; then
         local cluster_name
+        local cluster_uuid
         local version
         cluster_name=$(grep -o '"cluster_name"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
+        cluster_uuid=$(grep -o '"cluster_uuid"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
         version=$(grep -o '"number"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
 
         if [[ -n "$cluster_name" ]]; then
-          print_info "Cluster: $cluster_name"
+          if [[ -n "$cluster_uuid" ]]; then
+            print_info "Cluster: $cluster_name ($cluster_uuid)"
+          else
+            print_info "Cluster: $cluster_name"
+          fi
         fi
         if [[ -n "$version" ]]; then
           print_info "Version: $version"
@@ -528,6 +557,12 @@ check_elasticsearch() {
         print_warning "$ca_warning"
         ((CHECKS_WARNED++))
       fi
+
+      ES_CLUSTER_ID="$cluster_uuid"
+      ES_CLUSTER_NAME="$cluster_name"
+      ES_VERSION="$version"
+      ES_LICENSE_UID="$license_uid"
+      ES_LICENSE_TYPE="$license_type"
 
       ((CHECKS_PASSED++))
       return 0

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -387,7 +387,7 @@ test_cloud_api_with_es_payload_rejected() {
   start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}' \
-    "/api/v1/cloud-connected/clusters" 403 '{"error": "Forbidden"}'
+    "/api/v1/cloud-connected/clusters" 403 '{"errors":[{"code":"cluster.already_registered","message":"Cluster is already registered"}]}'
 
   local output
   local exit_code=0
@@ -403,7 +403,7 @@ test_cloud_api_with_es_payload_rejected() {
   stop_mock_server
 
   assert_exit_code 1 "$exit_code"
-  assert_output_contains "❌ FAIL:    Registration failed (HTTP 403)." "$output"
+  assert_output_contains "Registration failed (HTTP 403) (cluster.already_registered: Cluster is already registered)." "$output"
 }
 
 test_otel_success() {

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -355,6 +355,32 @@ test_cloud_api_connection_refused() {
   assert_output_contains "❌ FAIL:" "$output"
 }
 
+test_cloud_api_with_es_payload() {
+  log_test "Cloud API - POSTs ES cluster data when API key provided"
+
+  start_path_mock_server 4 \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}' \
+    "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
+    "/v1/logs" 200 '{"ok": true}'
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    ELASTIC_CLOUD_CONNECTED_MODE_API_KEY="test-cloud-api-key" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_exit_code 0 "$exit_code"
+  assert_output_contains "✅ SUCCESS: Reachable. Can register to Elastic Cloud." "$output"
+}
+
 test_otel_success() {
   log_test "OTel endpoint - successful connection"
 
@@ -449,7 +475,7 @@ test_elasticsearch_success() {
   log_test "Elasticsearch - successful connection"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -465,7 +491,7 @@ test_elasticsearch_success() {
   stop_mock_server
 
   assert_output_contains "✅ SUCCESS: Connected successfully (HTTP 200)" "$output"
-  assert_output_contains "ℹ️  INFO:    Cluster: test-cluster" "$output"
+  assert_output_contains "ℹ️  INFO:    Cluster: test-cluster (test-uuid-abcd)" "$output"
   assert_output_contains "ℹ️  INFO:    Version: 8.12.0" "$output"
   assert_output_contains "License: active (basic: test-uid-1234)" "$output"
 }
@@ -474,7 +500,7 @@ test_elasticsearch_with_api_key() {
   log_test "Elasticsearch - API key authentication display"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -499,7 +525,7 @@ test_elasticsearch_api_key_with_colon() {
   start_path_mock_server 4 \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
     "/v1/logs" 200 '{"ok": true}' \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -523,7 +549,7 @@ test_elasticsearch_with_basic_auth() {
   log_test "Elasticsearch - Basic authentication display"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -656,7 +682,7 @@ test_elasticsearch_license_inactive() {
   log_test "Elasticsearch - license not active"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "expired"}}'
 
   local output
@@ -679,7 +705,7 @@ test_elasticsearch_license_active() {
   log_test "Elasticsearch - license active"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -910,7 +936,7 @@ test_elasticsearch_license_inactive() {
   log_test "Elasticsearch - license not active"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "expired"}}'
 
   local output
@@ -933,7 +959,7 @@ test_elasticsearch_license_active() {
   log_test "Elasticsearch - license active with type and uid"
 
   start_path_mock_server 2 \
-    "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "platinum", "uid": "abcd-1234-efgh"}}'
 
   local output
@@ -1031,6 +1057,7 @@ run_all_tests() {
   test_elasticsearch_license_active
   test_cloud_api_success
   test_cloud_api_connection_refused
+  test_cloud_api_with_es_payload
   test_otel_success
   test_otel_default_url
   test_cloud_api_default_url

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -1034,6 +1034,42 @@ test_no_proxy_hint_without_proxy() {
   assert_output_not_contains "proxy is configured" "$output"
 }
 
+test_connection_timeout_port_extraction() {
+  log_test "Connection timeout - port extracted from calling method URLs"
+
+  # Extract only the two functions needed, no main execution or side effects
+  local fn_script
+  fn_script=$(mktemp)
+  {
+    sed -n '/^extract_port_from_url()/,/^}/p' "$CHECK_SCRIPT"
+    sed -n '/^interpret_curl_error()/,/^}/p' "$CHECK_SCRIPT"
+  } > "$fn_script"
+
+  run_interpret() {
+    bash -c "source '$fn_script'; interpret_curl_error \"\$@\"" -- "$@"
+  }
+
+  local result
+
+  # check_cloud_api default: https with no explicit port → 443
+  result=$(run_interpret 28 "" "https://api.elastic-cloud.com/api/v1/cloud-connected/clusters")
+  assert_output_contains "Port 443" "$result"
+
+  # check_otel default: https with no explicit port → 443
+  result=$(run_interpret 28 "" "https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs")
+  assert_output_contains "Port 443" "$result"
+
+  # check_elasticsearch with HTTP and explicit port → 9200
+  result=$(run_interpret 28 "" "http://localhost:9200/")
+  assert_output_contains "Port 9200" "$result"
+
+  # check_elasticsearch with HTTPS and explicit port → 9243
+  result=$(run_interpret 28 "" "https://my-es.example.com:9243/_license")
+  assert_output_contains "Port 9243" "$result"
+
+  rm -f "$fn_script"
+}
+
 # ---------------------------
 # Run all tests
 # ---------------------------
@@ -1098,6 +1134,7 @@ run_all_tests() {
   test_unknown_argument
   test_proxy_hint_on_connection_failure
   test_no_proxy_hint_without_proxy
+  test_connection_timeout_port_extraction
 
   # Print summary
   echo ""

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -1017,12 +1017,6 @@ run_all_tests() {
   test_proxy_detection_with_proxy
   test_proxy_http_without_https
   test_proxy_no_warning_when_https_set
-  test_cloud_api_success
-  test_cloud_api_connection_refused
-  test_otel_success
-  test_otel_default_url
-  test_cloud_api_default_url
-  test_no_default_indicator_when_custom_url
   test_elasticsearch_skipped
   test_elasticsearch_success
   test_elasticsearch_with_api_key
@@ -1035,6 +1029,12 @@ run_all_tests() {
   test_elasticsearch_version_exact_minimum
   test_elasticsearch_license_inactive
   test_elasticsearch_license_active
+  test_cloud_api_success
+  test_cloud_api_connection_refused
+  test_otel_success
+  test_otel_default_url
+  test_cloud_api_default_url
+  test_no_default_indicator_when_custom_url
   test_value_masking
   test_summary_all_pass
   test_summary_some_fail

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -381,6 +381,31 @@ test_cloud_api_with_es_payload() {
   assert_output_contains "✅ SUCCESS: Reachable. Can register to Elastic Cloud." "$output"
 }
 
+test_cloud_api_with_es_payload_rejected() {
+  log_test "Cloud API - registration fails on non-200/201 response"
+
+  start_path_mock_server 3 \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}' \
+    "/api/v1/cloud-connected/clusters" 403 '{"error": "Forbidden"}'
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    ELASTIC_CLOUD_CONNECTED_MODE_API_KEY="test-cloud-api-key" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_exit_code 1 "$exit_code"
+  assert_output_contains "❌ FAIL:    Registration failed (HTTP 403)." "$output"
+}
+
 test_otel_success() {
   log_test "OTel endpoint - successful connection"
 
@@ -1058,6 +1083,7 @@ run_all_tests() {
   test_cloud_api_success
   test_cloud_api_connection_refused
   test_cloud_api_with_es_payload
+  test_cloud_api_with_es_payload_rejected
   test_otel_success
   test_otel_default_url
   test_cloud_api_default_url

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -378,7 +378,7 @@ test_cloud_api_with_es_payload() {
   stop_mock_server
 
   assert_exit_code 0 "$exit_code"
-  assert_output_contains "✅ SUCCESS: Reachable. Can register to Elastic Cloud." "$output"
+  assert_output_contains "✅ SUCCESS: Reachable. The cluster has been registered to Elastic Cloud." "$output"
 }
 
 test_cloud_api_with_es_payload_rejected() {


### PR DESCRIPTION
This changes a few things to help to surface a new type of issue: errors with the Cloud Connect API.

1. This moves execution of Elasticsearch checks to be first. It can still be skipped.
2. If Elasticsearch checks succeed, we will now capture the cluster info and license info (we already called the endpoints, now we just remember the result rather than validating, logging, and moving on).
3. If Elasticsearch checks succeed _and_ a new environment variable named `ELASTIC_CLOUD_CONNECTED_MODE_API_KEY` is provided, we will use the information collected in step 2 to attempt to register the cluster from the diagnostic script.
4. If this fails, we will print the exact error message.

Closes https://github.com/elastic/autoops-install/issues/25

Example skipping ES cluster checks:

```
% ./tools/check_connectivity.sh

========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    No proxy detected; using direct connection.

--- Elasticsearch ---
  ⚠️ SKIPPED: Elasticsearch check skipped (AUTOOPS_ES_URL not set). Set AUTOOPS_ES_URL to enable connectivity testing

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ✅ SUCCESS: Reachable. Can register to Elastic Cloud.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Summary ---

  Passed:  2
  Failed:  0
  Skipped: 1

  ✅ SUCCESS: Elastic Cloud connectivity checks passed.
  ⚠️ SKIPPED: The Elasticsearch environment was not checked.
```

Example running with an invalid ES cluster, thus not registering:

```
% AUTOOPS_ES_URL=http://localhost:9241 ./tools/check_connectivity.sh

========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    No proxy detected; using direct connection.

--- Elasticsearch ---
  ℹ️ INFO:    URL: http://localhost:9241
  ℹ️ INFO:    Auth: none
  ℹ️ INFO:    Checking connectivity to http://localhost:9241/...
  ❌ FAIL:    Connection refused. Check the server and port.

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ✅ SUCCESS: Reachable. Can register to Elastic Cloud.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Summary ---

  Passed:  2
  Failed:  1
  Skipped: 0

  ❌ FAIL:    Connectivity issues detected. AutoOps Agent will not function.

  Review the troubleshooting guide and address issues before running the agent:
  https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting
```

Example running with a valid ES cluster, but failing to register:

```
% AUTOOPS_ES_URL=http://localhost:9200 ELASTIC_CLOUD_CONNECTED_MODE_API_KEY='invalid_auth' ./tools/check_connectivity.sh     

========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    No proxy detected; using direct connection.

--- Elasticsearch ---
  ℹ️ INFO:    URL: http://localhost:9200
  ℹ️ INFO:    Auth: none
  ℹ️ INFO:    Checking connectivity to http://localhost:9200/...
  ✅ SUCCESS: Connected successfully (HTTP 200)
  ℹ️ INFO:    Cluster: docker-cluster (7xdeWjAVSb6a7L91vkqBcQ)
  ℹ️ INFO:    Version: 8.19.3
  ℹ️ INFO:    Checking license status at http://localhost:9200/_license...
  ✅ SUCCESS: License: active (basic: 4856dba5-d9d8-41c3-b1b8-32b2cf486248)

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ❌ FAIL:    Registration failed (HTTP 401) (root.unauthenticated: The supplied authentication is invalid).

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Summary ---

  Passed:  2
  Failed:  1
  Skipped: 0

  ❌ FAIL:    Connectivity issues detected. AutoOps Agent will not function.

  Review the troubleshooting guide and address issues before running the agent:
  https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting
```

Example running with a valid ES cluster, succeeding to register:

```
% AUTOOPS_ES_URL=http://localhost:9200 ELASTIC_CLOUD_CONNECTED_MODE_API_KEY='valid_auth' ELASTIC_CLOUD_CONNECTED_MODE_API_URL='https://path-to-test-ccm' ./tools/check_connectivity.sh

========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    No proxy detected; using direct connection.

--- Elasticsearch ---
  ℹ️ INFO:    URL: http://localhost:9200
  ℹ️ INFO:    Auth: none
  ℹ️ INFO:    Checking connectivity to http://localhost:9200/...
  ✅ SUCCESS: Connected successfully (HTTP 200)
  ℹ️ INFO:    Cluster: docker-cluster (7xdeWjAVSb6a7L91vkqBcQ)
  ℹ️ INFO:    Version: 8.19.3
  ℹ️ INFO:    Checking license status at http://localhost:9200/_license...
  ✅ SUCCESS: License: active (basic: 4856dba5-d9d8-41c3-b1b8-32b2cf486248)

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://path-to-test-ccm
  ℹ️ INFO:    Checking connectivity to https://path-to-test-ccm/api/v1/cloud-connected/clusters...
  ✅ SUCCESS: Reachable. The cluster has been registered to Elastic Cloud.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Summary ---

  Passed:  3
  Failed:  0
  Skipped: 0

  ✅ SUCCESS: All checks passed. The environment is ready to use AutoOps.
```