### PR TITLE
[Kubernetes] Workaround OTel Batch Sizer issue

### DIFF
--- a/k8s/autoops_agent_deployment.yaml
+++ b/k8s/autoops_agent_deployment.yaml
@@ -33,6 +33,12 @@ spec:
         - args:
             - '--config'
             - otel_samples/autoops_es.yml
+            # TODO: Remove these lines after 9.3.2+ (https://github.com/elastic/elastic-agent/pull/13093)
+            - '--set'
+            - 'exporters::otlphttp::sending_queue::sizer=requests'
+            - '--set'
+            - 'exporters::otlphttp::sending_queue::batch::sizer=bytes'
+            # END TODO
           env:
             - name: AUTOOPS_TOKEN
               valueFrom:


### PR DESCRIPTION
This applies a workaround to an issue (https://github.com/elastic/elastic-agent/issues/13092) that occurs when running the OTel Exporter ignores the batch sending sizer. This will be fixed in the next release (https://github.com/elastic/elastic-agent/pull/13093), but until this is released users can use this workaround.

There is no solution for the Linux script currently because specifying these flags by rewriting `ExecStart=` results in it not recognizing `--set` and exiting. I will work with the Elastic Agent team to see if there is or can be.