### PR TITLE
[Linux] Simplify Installed Environment

### DIFF
--- a/linux/install_autoops.sh
+++ b/linux/install_autoops.sh
@@ -186,11 +186,24 @@ Environment="AUTOOPS_OTEL_URL=${AUTOOPS_OTEL_URL}"
 Environment="AUTOOPS_TOKEN=${AUTOOPS_TOKEN}"
 Environment="AUTOOPS_TEMP_RESOURCE_ID=${AUTOOPS_TEMP_RESOURCE_ID}"
 Environment="ELASTIC_CLOUD_CONNECTED_MODE_API_KEY=${ELASTIC_CLOUD_CONNECTED_MODE_API_KEY}"
+EOF
+
+if [[ -n "${ELASTIC_CLOUD_CONNECTED_MODE_API_URL}" ]]; then
+  sudo tee -a /etc/systemd/system/elastic-agent.service.d/autoops-env.conf >/dev/null <<EOF
 Environment="ELASTIC_CLOUD_CONNECTED_MODE_API_URL=${ELASTIC_CLOUD_CONNECTED_MODE_API_URL}"
-Environment="AUTOOPS_ES_USERNAME=${AUTOOPS_ES_USERNAME}"
-Environment="AUTOOPS_ES_PASSWORD=${AUTOOPS_ES_PASSWORD}"
+EOF
+fi
+
+if [[ -n "${AUTOOPS_ES_API_KEY}" ]]; then
+  sudo tee -a /etc/systemd/system/elastic-agent.service.d/autoops-env.conf >/dev/null <<EOF
 Environment="AUTOOPS_ES_API_KEY=${AUTOOPS_ES_API_KEY}"
 EOF
+elif [[ -n "${AUTOOPS_ES_USERNAME}" && -n "${AUTOOPS_ES_PASSWORD}" ]]; then
+  sudo tee -a /etc/systemd/system/elastic-agent.service.d/autoops-env.conf >/dev/null <<EOF
+Environment="AUTOOPS_ES_USERNAME=${AUTOOPS_ES_USERNAME}"
+Environment="AUTOOPS_ES_PASSWORD=${AUTOOPS_ES_PASSWORD}"
+EOF
+fi
 
 sudo systemctl daemon-reexec
 sudo systemctl daemon-reload


### PR DESCRIPTION
This removes unused environment variables from the systemd configuration when possible (i.e., you supply an API Key, we do not need to define blank username / password fields and vice versa).