### PR TITLE
[Diagnostic] Redact HTTP proxy URL credentials

### DIFF
--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -94,6 +94,17 @@ mask_value() {
   echo "**REDACTED**"
 }
 
+# Redact user:password credentials embedded in a URL, e.g.
+#   http://user:pass@host:8080 -> http://**REDACTED**:**REDACTED**@host:8080
+redact_url_credentials() {
+  local url="$1"
+  if [[ "$url" =~ ^([a-zA-Z][a-zA-Z0-9+.-]*)://([^:@]+):([^@]+)@(.+)$ ]]; then
+    echo "${BASH_REMATCH[1]}://**REDACTED**:**REDACTED**@${BASH_REMATCH[4]}"
+  else
+    echo "$url"
+  fi
+}
+
 # ---------------------------
 # Temporary file cleanup
 # ---------------------------
@@ -235,7 +246,7 @@ check_proxy() {
     local value="${!var:-}"
     if [[ -n "$value" ]]; then
       proxy_found=1
-      print_info "$var=$value"
+      print_info "$var=$(redact_url_credentials "$value")"
     fi
   done
 

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -319,6 +319,60 @@ test_proxy_no_warning_when_https_set() {
   assert_output_not_contains "HTTPS_PROXY is missing" "$output"
 }
 
+test_proxy_no_credentials_unchanged() {
+  log_test "Proxy redaction - URL without credentials is unchanged"
+
+  local output
+  local exit_code=0
+
+  output=$(
+    unset http_proxy https_proxy no_proxy all_proxy
+    HTTP_PROXY="http://myproxy.example.com:8080" \
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  assert_output_contains "HTTP_PROXY=http://myproxy.example.com:8080" "$output"
+}
+
+test_proxy_credentials_redacted() {
+  log_test "Proxy redaction - credentials in URL are redacted"
+
+  local output
+  local exit_code=0
+
+  output=$(
+    unset http_proxy https_proxy no_proxy all_proxy
+    HTTP_PROXY="http://alice:s3cr3t@proxy.corp:3128" \
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  assert_output_contains 'HTTP_PROXY=http://\*\*REDACTED\*\*:\*\*REDACTED\*\*@proxy.corp:3128' "$output"
+  assert_output_not_contains "alice" "$output"
+  assert_output_not_contains "s3cr3t" "$output"
+}
+
+test_proxy_https_credentials_redacted() {
+  log_test "Proxy redaction - credentials redacted in HTTPS_PROXY"
+
+  local output
+  local exit_code=0
+
+  output=$(
+    unset http_proxy https_proxy no_proxy all_proxy HTTP_PROXY
+    HTTPS_PROXY="https://bob:p%40ss@secureproxy.corp:8443" \
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  assert_output_contains 'HTTPS_PROXY=https://\*\*REDACTED\*\*:\*\*REDACTED\*\*@secureproxy.corp:8443' "$output"
+  assert_output_not_contains "bob" "$output"
+}
+
 test_cloud_api_success() {
   log_test "Cloud API - successful connection"
 
@@ -1017,6 +1071,9 @@ run_all_tests() {
   test_proxy_detection_with_proxy
   test_proxy_http_without_https
   test_proxy_no_warning_when_https_set
+  test_proxy_no_credentials_unchanged
+  test_proxy_credentials_redacted
+  test_proxy_https_credentials_redacted
   test_cloud_api_success
   test_cloud_api_connection_refused
   test_otel_success


### PR DESCRIPTION
It is not uncommon to embed credentials in URLs for HTTP proxy values, so this ensures that they are not printed to the screen.

```
HTTP_PROXY=http://user:pa$$@localhost:1234 HTTPS_PROXY=https://not-redacted ./tools/check_connectivity.sh

========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️ INFO:    HTTP_PROXY=http://**REDACTED**:**REDACTED**@localhost:1234
  ℹ️ INFO:    HTTPS_PROXY=https://not-redacted

--- Elastic Cloud Connected Mode API ---
  ℹ️ INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️ INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ❌ FAIL:    Could not resolve proxy host.

--- OTel Endpoint ---
  ℹ️ INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️ INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ❌ FAIL:    Could not resolve proxy host.

--- Elasticsearch ---
  ⚠️ SKIPPED: Elasticsearch check skipped (AUTOOPS_ES_URL not set). Set AUTOOPS_ES_URL to enable connectivity testing

--- Summary ---

  Passed:  0
  Failed:  2
  Skipped: 1

  ❌ FAIL:    Connectivity issues detected. AutoOps Agent will not function.

  Review the troubleshooting guide and address issues before running the agent:
  https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting
```