### PR TITLE
[Agent] Use 9.3.2

### DIFF
--- a/k8s/autoops_agent_deployment.yaml
+++ b/k8s/autoops_agent_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: autoops-elastic-agent
     app.kubernetes.io/component: autoops
     app.kubernetes.io/name: autoops-elastic-agent
-    app.kubernetes.io/version: 9.3.1
+    app.kubernetes.io/version: 9.3.2
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -33,12 +33,6 @@ spec:
         - args:
             - '--config'
             - otel_samples/autoops_es.yml
-            # TODO: Remove these lines after 9.3.2+ (https://github.com/elastic/elastic-agent/pull/13093)
-            - '--set'
-            - 'exporters::otlphttp::sending_queue::sizer=requests'
-            - '--set'
-            - 'exporters::otlphttp::sending_queue::batch::sizer=bytes'
-            # END TODO
           env:
             - name: AUTOOPS_TOKEN
               valueFrom:
@@ -91,7 +85,7 @@ spec:
                   key: cloud-connected-mode-api-url
                   optional: true
           image: >-
-            docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.3.1
+            docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.3.2
           imagePullPolicy: Always
           name: autoops-elastic-agent
           resources: {}

--- a/linux/install_autoops.sh
+++ b/linux/install_autoops.sh
@@ -21,7 +21,7 @@
 # Configurable defaults
 # ---------------------------
 DOWNLOAD_URL="https://artifacts.elastic.co/downloads/beats/elastic-agent"
-VERSION="9.3.1"
+VERSION="9.3.2"
 DO_NOT_DELETE=false
 CACHE_DIR="${AUTOOPS_CACHE_DIR:-$HOME/.cache/elastic-agent-installer}"
 ELASTIC_CLOUD_CONNECTED_MODE_API_URL=""


### PR DESCRIPTION
This upgrades to use Elastic Agent 9.3.2, which allows us to drop the customization for K8s (that couldn't exist for Linux).