### PR TITLE
[Diagnostic] Use AUTOOPS_TOKEN if possible

### DIFF
--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -328,26 +328,40 @@ check_otel() {
     using_default=" (default)"
   fi
   local check_url="${otel_url}/v1/logs"
+  local autoops_token="${AUTOOPS_TOKEN:-}"
 
   print_info "URL: ${otel_url}${using_default}"
+  if [[ -n "$autoops_token" ]]; then
+    print_info "AUTOOPS_TOKEN: $(mask_value "$autoops_token")"
+  fi
   print_check "connectivity to ${check_url}"
 
   local http_code
   local curl_exit
 
-  http_code=$(curl -sS -X POST \
-    -H "Content-Length: 0" \
-    -w "%{http_code}" \
-    -o /dev/null \
-    --connect-timeout 10 \
-    --max-time 30 \
-    "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  if [[ -n "$autoops_token" ]]; then
+    http_code=$(curl -sS -X POST \
+      -H "Content-Length: 0" \
+      -H "Authorization: AutoOpsToken ${autoops_token}" \
+      -w "%{http_code}" \
+      -o "${RESPONSE_FILE}" \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  else
+    http_code=$(curl -sS -X POST \
+      -H "Content-Length: 0" \
+      -w "%{http_code}" \
+      -o "${RESPONSE_FILE}" \
+      --connect-timeout 10 \
+      --max-time 30 \
+      "${check_url}" 2>"${ERROR_FILE}") || curl_exit=$?
+  fi
 
   curl_exit=${curl_exit:-0}
 
   if [[ $curl_exit -ne 0 ]]; then
-    local error_msg
-    error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)" "$check_url")
+    local error_msg=$(interpret_curl_error "$curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)" "$check_url")
     print_error "$error_msg"
     if [[ "$PROXY_CONFIGURED" == "true" && "$curl_exit" != "5" && "$curl_exit" != "97" ]]; then
       print_warning "A proxy is configured — this may be causing the connection failure"
@@ -356,13 +370,36 @@ check_otel() {
     return 1
   fi
 
-  if [[ "$DEBUG" == "true" ]]; then
-    print_success "Reachable. Can ship metrics to Elastic Cloud. (HTTP $http_code)"
+  if [[ -n "$autoops_token" ]]; then
+    if [[ "$http_code" == "415" ]]; then
+      if [[ "$DEBUG" == "true" ]]; then
+        print_success "Reachable and authenticated. Can ship metrics to Elastic Cloud. (HTTP $http_code)"
+      else
+        print_success "Reachable and authenticated. Can ship metrics to Elastic Cloud."
+      fi
+      ((CHECKS_PASSED++))
+      return 0
+    else
+      print_error "Reachable but authentication failed or unexpected response. (HTTP $http_code)"
+      ((CHECKS_FAILED++))
+      return 1
+    fi
   else
-    print_success "Reachable. Can ship metrics to Elastic Cloud."
+    local response_body=$(cat "${RESPONSE_FILE}" 2>/dev/null)
+    if [[ "$http_code" == "401" && "$response_body" == *'"code":16'* && "$response_body" == *'"message":"no auth provided"'* ]]; then
+      if [[ "$DEBUG" == "true" ]]; then
+        print_success "Reachable. Can ship metrics to Elastic Cloud. (HTTP $http_code)"
+      else
+        print_success "Reachable. Can ship metrics to Elastic Cloud."
+      fi
+      ((CHECKS_PASSED++))
+      return 0
+    else
+      print_error "Reachable but unexpected response (HTTP $http_code). Set AUTOOPS_TOKEN to validate authentication end-to-end."
+      ((CHECKS_FAILED++))
+      return 1
+    fi
   fi
-  ((CHECKS_PASSED++))
-  return 0
 }
 
 # ---------------------------

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -410,14 +410,15 @@ test_cloud_api_connection_refused() {
 }
 
 test_otel_success() {
-  log_test "OTel endpoint - successful connection"
+  log_test "OTel endpoint - successful connection without token (HTTP 401 + no auth body)"
 
-  start_mock_server "200" '{"status": "ok"}'
+  start_mock_server "401" '{"code":16,"message":"no auth provided"}'
 
   local output
   local exit_code=0
 
   output=$(
+    unset AUTOOPS_TOKEN
     ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
     AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
     bash "$CHECK_SCRIPT" 2>&1
@@ -427,7 +428,91 @@ test_otel_success() {
 
   assert_output_contains "OTel Endpoint" "$output"
   assert_output_contains "✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud." "$output"
-  assert_output_not_contains "HTTP 200" "$output"
+  assert_output_not_contains "HTTP 401" "$output"
+}
+
+test_otel_no_token_unexpected_response() {
+  log_test "OTel endpoint - fails on unexpected response without token"
+
+  start_mock_server "200" '{"status": "ok"}'
+
+  local output
+  local exit_code=0
+
+  output=$(
+    unset AUTOOPS_TOKEN
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_output_contains "Reachable but unexpected response (HTTP 200)" "$output"
+  assert_output_contains "Set AUTOOPS_TOKEN to validate authentication end-to-end" "$output"
+}
+
+test_otel_with_token_success() {
+  log_test "OTel endpoint - authenticated success with AUTOOPS_TOKEN (HTTP 415)"
+
+  start_mock_server "415" ''
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_TOKEN="my-test-token" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_output_contains "✅ SUCCESS: Reachable and authenticated. Can ship metrics to Elastic Cloud." "$output"
+  assert_output_not_contains "HTTP 415" "$output"
+}
+
+test_otel_with_token_auth_failure() {
+  log_test "OTel endpoint - fails when token provided but server returns non-415"
+
+  start_mock_server "401" '{"code":16,"message":"no auth provided"}'
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_TOKEN="bad-token" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_output_contains "Reachable but authentication failed or unexpected response. (HTTP 401)" "$output"
+}
+
+test_otel_token_masked_in_output() {
+  log_test "OTel endpoint - AUTOOPS_TOKEN value is masked in output"
+
+  start_mock_server "415" ''
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_TOKEN="super-secret-token" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_output_contains "AUTOOPS_TOKEN:" "$output"
+  assert_output_not_contains "super-secret-token" "$output"
+  assert_output_contains "REDACTED" "$output"
 }
 
 test_otel_default_url() {
@@ -552,7 +637,7 @@ test_elasticsearch_api_key_with_colon() {
 
   start_path_mock_server 4 \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
-    "/v1/logs" 200 '{"ok": true}' \
+    "/v1/logs" 401 '{"code":16,"message":"no auth provided"}' \
     "/" 200 '{"cluster_name": "test-cluster", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
@@ -560,6 +645,7 @@ test_elasticsearch_api_key_with_colon() {
   local exit_code=0
 
   output=$(
+    unset AUTOOPS_TOKEN
     ELASTIC_CLOUD_CONNECTED_MODE_API_URL="${MOCK_SERVER_URL}" \
     AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
     AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
@@ -781,7 +867,7 @@ test_summary_all_pass() {
 
   start_path_mock_server 4 \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
-    "/v1/logs" 200 '{"ok": true}' \
+    "/v1/logs" 401 '{"code":16,"message":"no auth provided"}' \
     "/" 200 '{"cluster_name": "test", "version": {"number": "8.12.0"}}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
@@ -789,6 +875,7 @@ test_summary_all_pass() {
   local exit_code=0
 
   output=$(
+    unset AUTOOPS_TOKEN
     ELASTIC_CLOUD_CONNECTED_MODE_API_URL="${MOCK_SERVER_URL}" \
     AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
     AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
@@ -824,12 +911,13 @@ test_summary_skipped() {
 
   start_path_mock_server 2 \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
-    "/v1/logs" 200 '{"ok": true}'
+    "/v1/logs" 401 '{"code":16,"message":"no auth provided"}'
 
   local output
   local exit_code=0
 
   output=$(
+    unset AUTOOPS_TOKEN
     ELASTIC_CLOUD_CONNECTED_MODE_API_URL="${MOCK_SERVER_URL}" \
     AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
     bash "$CHECK_SCRIPT" 2>&1
@@ -884,14 +972,15 @@ test_debug_flag_shows_http_code() {
 }
 
 test_debug_flag_otel_shows_http_code() {
-  log_test "Debug flag - OTel shows HTTP code with --debug"
+  log_test "Debug flag - OTel shows HTTP 401 code with --debug (no token)"
 
-  start_mock_server "200" '{"status": "ok"}'
+  start_mock_server "401" '{"code":16,"message":"no auth provided"}'
 
   local output
   local exit_code=0
 
   output=$(
+    unset AUTOOPS_TOKEN
     ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
     AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
     bash "$CHECK_SCRIPT" --debug 2>&1
@@ -899,7 +988,27 @@ test_debug_flag_otel_shows_http_code() {
 
   stop_mock_server
 
-  assert_output_contains "Can ship metrics to Elastic Cloud. (HTTP 200)" "$output"
+  assert_output_contains "Can ship metrics to Elastic Cloud. (HTTP 401)" "$output"
+}
+
+test_debug_flag_otel_shows_http_code_with_token() {
+  log_test "Debug flag - OTel shows HTTP 415 code with --debug and AUTOOPS_TOKEN"
+
+  start_mock_server "415" ''
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_TOKEN="my-test-token" \
+    bash "$CHECK_SCRIPT" --debug 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_output_contains "Can ship metrics to Elastic Cloud. (HTTP 415)" "$output"
 }
 
 test_unknown_argument() {
@@ -1077,6 +1186,10 @@ run_all_tests() {
   test_cloud_api_success
   test_cloud_api_connection_refused
   test_otel_success
+  test_otel_no_token_unexpected_response
+  test_otel_with_token_success
+  test_otel_with_token_auth_failure
+  test_otel_token_masked_in_output
   test_otel_default_url
   test_cloud_api_default_url
   test_no_default_indicator_when_custom_url
@@ -1099,6 +1212,7 @@ run_all_tests() {
   test_curl_not_installed
   test_debug_flag_shows_http_code
   test_debug_flag_otel_shows_http_code
+  test_debug_flag_otel_shows_http_code_with_token
   test_unknown_argument
   test_proxy_hint_on_connection_failure
   test_no_proxy_hint_without_proxy


### PR DESCRIPTION
This updates the check for the OTel Collector to ensure that the response looks like our response, rather than a reachable response that is coming from something else (i.e., a proxy).

Closes https://github.com/elastic/autoops-install/issues/42