### PR TITLE
[Agent] Use 9.3.3

### DIFF
--- a/k8s/autoops_agent_deployment.yaml
+++ b/k8s/autoops_agent_deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: autoops-elastic-agent
     app.kubernetes.io/component: autoops
     app.kubernetes.io/name: autoops-elastic-agent
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.3
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -85,7 +85,7 @@ spec:
                   key: cloud-connected-mode-api-url
                   optional: true
           image: >-
-            docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.3.2
+            docker.elastic.co/elastic-agent/elastic-otel-collector-wolfi:9.3.3
           imagePullPolicy: Always
           name: autoops-elastic-agent
           resources: {}

--- a/linux/install_autoops.sh
+++ b/linux/install_autoops.sh
@@ -21,7 +21,7 @@
 # Configurable defaults
 # ---------------------------
 DOWNLOAD_URL="https://artifacts.elastic.co/downloads/beats/elastic-agent"
-VERSION="9.3.2"
+VERSION="9.3.3"
 DO_NOT_DELETE=false
 CACHE_DIR="${AUTOOPS_CACHE_DIR:-$HOME/.cache/elastic-agent-installer}"
 ELASTIC_CLOUD_CONNECTED_MODE_API_URL=""


### PR DESCRIPTION
This upgrades the agent to use 9.3.3 instead of 9.3.2. This helps to reduce unnecessary logging (repeated success).

Relates https://github.com/elastic/beats/pull/49507