### PR TITLE
[Diagnostic] Add `display_name` from `/_cluster/settings`

### DIFF
--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -387,19 +387,61 @@ check_elasticsearch() {
         cluster_uuid=$(grep -o '"cluster_uuid"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
         version=$(grep -o '"number"[[:space:]]*:[[:space:]]*"[^"]*"' "${RESPONSE_FILE}" 2>/dev/null | head -1 | sed 's/.*:.*"\([^"]*\)".*/\1/')
 
-        if [[ -n "$cluster_name" ]]; then
-          if [[ -n "$cluster_uuid" ]]; then
-            print_info "Cluster: $cluster_name ($cluster_uuid)"
-          else
-            print_info "Cluster: $cluster_name"
-          fi
-        fi
         if [[ -n "$version" ]]; then
           print_info "Version: $version"
           if ! version_at_least "$version" "7.17.0"; then
             print_error "Elasticsearch version $version is below the minimum required version 7.17.0"
             ((CHECKS_FAILED++))
             return 1
+          fi
+        fi
+
+        # Fetch cluster display name from settings
+        local settings_url="${AUTOOPS_ES_URL%/}/_cluster/settings?filter_path=*.cluster\.metadata\.display_name&flat_settings=true"
+        print_check "cluster settings at ${AUTOOPS_ES_URL%/}/_cluster/settings"
+
+        local settings_http_code
+        local settings_curl_exit
+        settings_http_code=$(curl -sS \
+          "${ca_opts[@]}" \
+          "${auth_opts[@]}" \
+          -w "%{http_code}" \
+          -o "${RESPONSE_FILE}" \
+          --connect-timeout 10 \
+          --max-time 30 \
+          "${settings_url}" 2>"${ERROR_FILE}") || settings_curl_exit=$?
+
+        settings_curl_exit=${settings_curl_exit:-0}
+
+        if [[ $settings_curl_exit -ne 0 ]]; then
+          local error_msg
+          error_msg=$(interpret_curl_error "$settings_curl_exit" "$(cat "${ERROR_FILE}" 2>/dev/null)" "$settings_url")
+          print_error "Cluster settings check failed: $error_msg"
+          if [[ "$PROXY_CONFIGURED" == "true" && "$settings_curl_exit" != "5" && "$settings_curl_exit" != "97" ]]; then
+            print_warning "A proxy is configured — this may be causing the connection failure"
+          fi
+          ((CHECKS_FAILED++))
+          return 1
+        fi
+
+        if [[ "$settings_http_code" != "200" ]]; then
+          print_error "Cluster settings check failed (HTTP $settings_http_code)"
+          ((CHECKS_FAILED++))
+          return 1
+        fi
+
+        local transient_block persistent_block transient_display persistent_display display_name
+        transient_block=$(grep -o '"transient"[[:space:]]*:[[:space:]]*{[^}]*}' "${RESPONSE_FILE}" 2>/dev/null | head -1)
+        persistent_block=$(grep -o '"persistent"[[:space:]]*:[[:space:]]*{[^}]*}' "${RESPONSE_FILE}" 2>/dev/null | head -1)
+        transient_display=$(echo "$transient_block" | grep -o '"cluster\.metadata\.display_name"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | head -1 | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/')
+        persistent_display=$(echo "$persistent_block" | grep -o '"cluster\.metadata\.display_name"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | head -1 | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/')
+        display_name="${transient_display:-${persistent_display:-$cluster_name}}"
+
+        if [[ -n "$display_name" ]]; then
+          if [[ -n "$cluster_uuid" ]]; then
+            print_info "Cluster: $display_name ($cluster_uuid)"
+          else
+            print_info "Cluster: $display_name"
           fi
         fi
 
@@ -470,7 +512,7 @@ check_elasticsearch() {
       fi
 
       ES_CLUSTER_ID="$cluster_uuid"
-      ES_CLUSTER_NAME="$cluster_name"
+      ES_CLUSTER_NAME="${display_name:-$cluster_name}"
       ES_VERSION="$version"
       ES_LICENSE_UID="$license_uid"
       ES_LICENSE_TYPE="$license_type"

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -213,7 +213,8 @@ class MockHandler(http.server.BaseHTTPRequestHandler):
         pass
 
     def do_GET(self):
-        code, body = ROUTES.get(self.path, (404, '{"error": "not found"}'))
+        path = self.path.split('?')[0]
+        code, body = ROUTES.get(path, (404, '{"error": "not found"}'))
         self.send_response(code)
         self.send_header('Content-Type', 'application/json')
         self.end_headers()
@@ -412,8 +413,9 @@ test_cloud_api_connection_refused() {
 test_cloud_api_with_es_payload() {
   log_test "Cloud API - POSTs ES cluster data when API key provided"
 
-  start_path_mock_server 4 \
+  start_path_mock_server 5 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}' \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
     "/v1/logs" 401 '{"code":16,"message":"no auth provided"}'
@@ -439,8 +441,9 @@ test_cloud_api_with_es_payload() {
 test_cloud_api_with_es_payload_rejected() {
   log_test "Cloud API - registration fails on non-200/201 response"
 
-  start_path_mock_server 3 \
+  start_path_mock_server 4 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}' \
     "/api/v1/cloud-connected/clusters" 403 '{"errors":[{"code":"cluster.already_registered","message":"Cluster is already registered"}]}'
 
@@ -639,8 +642,9 @@ test_elasticsearch_skipped() {
 test_elasticsearch_success() {
   log_test "Elasticsearch - successful connection"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -664,8 +668,9 @@ test_elasticsearch_success() {
 test_elasticsearch_with_api_key() {
   log_test "Elasticsearch - API key authentication display"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -687,10 +692,11 @@ test_elasticsearch_with_api_key() {
 test_elasticsearch_api_key_with_colon() {
   log_test "Elasticsearch - API key with colon is base64 encoded"
 
-  start_path_mock_server 4 \
+  start_path_mock_server 5 \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
     "/v1/logs" 401 '{"code":16,"message":"no auth provided"}' \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -714,8 +720,9 @@ test_elasticsearch_api_key_with_colon() {
 test_elasticsearch_with_basic_auth() {
   log_test "Elasticsearch - Basic authentication display"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -824,8 +831,9 @@ test_elasticsearch_version_too_old() {
 test_elasticsearch_version_exact_minimum() {
   log_test "Elasticsearch - version exactly at minimum 7.17.0"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "min-cluster", "version": {"number": "7.17.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -847,8 +855,9 @@ test_elasticsearch_version_exact_minimum() {
 test_elasticsearch_license_inactive() {
   log_test "Elasticsearch - license not active"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "expired"}}'
 
   local output
@@ -870,8 +879,9 @@ test_elasticsearch_license_inactive() {
 test_elasticsearch_license_active() {
   log_test "Elasticsearch - license active"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -893,8 +903,9 @@ test_elasticsearch_license_active() {
 test_value_masking() {
   log_test "Value masking - values are redacted"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -917,10 +928,11 @@ test_value_masking() {
 test_summary_all_pass() {
   log_test "Summary - all checks pass"
 
-  start_path_mock_server 4 \
+  start_path_mock_server 5 \
     "/api/v1/cloud-connected/clusters" 200 '{"ok": true}' \
     "/v1/logs" 401 '{"code":16,"message":"no auth provided"}' \
     "/" 200 '{"cluster_name": "test", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
 
   local output
@@ -1101,8 +1113,9 @@ test_elasticsearch_version_too_old() {
 test_elasticsearch_version_exact_minimum() {
   log_test "Elasticsearch - version exactly at minimum 7.17.0"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "min-cluster", "version": {"number": "7.17.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active"}}'
 
   local output
@@ -1124,8 +1137,9 @@ test_elasticsearch_version_exact_minimum() {
 test_elasticsearch_license_inactive() {
   log_test "Elasticsearch - license not active"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "expired"}}'
 
   local output
@@ -1147,8 +1161,9 @@ test_elasticsearch_license_inactive() {
 test_elasticsearch_license_active() {
   log_test "Elasticsearch - license active with type and uid"
 
-  start_path_mock_server 2 \
+  start_path_mock_server 3 \
     "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
     "/_license" 200 '{"license": {"status": "active", "type": "platinum", "uid": "abcd-1234-efgh"}}'
 
   local output
@@ -1234,6 +1249,98 @@ test_connection_timeout_port_extraction() {
   rm -f "$fn_script"
 }
 
+test_elasticsearch_display_name_transient() {
+  log_test "Elasticsearch - transient display name used as cluster name"
+
+  start_path_mock_server 3 \
+    "/" 200 '{"cluster_name": "raw-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{"transient":{"cluster.metadata.display_name":"Transient Display Name"},"persistent":{}}' \
+    "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
+
+  local output
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || true
+
+  stop_mock_server
+
+  assert_output_contains "Cluster: Transient Display Name (test-uuid-abcd)" "$output"
+  assert_output_not_contains "raw-cluster" "$output"
+}
+
+test_elasticsearch_display_name_persistent() {
+  log_test "Elasticsearch - persistent display name used as cluster name"
+
+  start_path_mock_server 3 \
+    "/" 200 '{"cluster_name": "raw-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{"transient":{},"persistent":{"cluster.metadata.display_name":"Persistent Display Name"}}' \
+    "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
+
+  local output
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || true
+
+  stop_mock_server
+
+  assert_output_contains "Cluster: Persistent Display Name (test-uuid-abcd)" "$output"
+  assert_output_not_contains "raw-cluster" "$output"
+}
+
+test_elasticsearch_display_name_transient_wins() {
+  log_test "Elasticsearch - transient display name takes priority over persistent"
+
+  start_path_mock_server 3 \
+    "/" 200 '{"cluster_name": "raw-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{"transient":{"cluster.metadata.display_name":"Transient Name"},"persistent":{"cluster.metadata.display_name":"Persistent Name"}}' \
+    "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
+
+  local output
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || true
+
+  stop_mock_server
+
+  assert_output_contains "Cluster: Transient Name (test-uuid-abcd)" "$output"
+  assert_output_not_contains "Persistent Name" "$output"
+}
+
+test_elasticsearch_settings_failure() {
+  log_test "Elasticsearch - cluster settings request failure causes error"
+
+  start_path_mock_server 2 \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 503 '{"error": "service unavailable"}'
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+
+  assert_exit_code 1 "$exit_code"
+  assert_output_contains "Cluster settings check failed (HTTP 503)" "$output"
+}
+
 # ---------------------------
 # Run all tests
 # ---------------------------
@@ -1283,6 +1390,10 @@ run_all_tests() {
   test_elasticsearch_version_exact_minimum
   test_elasticsearch_license_inactive
   test_elasticsearch_license_active
+  test_elasticsearch_display_name_transient
+  test_elasticsearch_display_name_persistent
+  test_elasticsearch_display_name_transient_wins
+  test_elasticsearch_settings_failure
   test_cloud_api_success
   test_cloud_api_connection_refused
   test_cloud_api_with_es_payload


### PR DESCRIPTION
This pulls in the `cluster.metadata.display_name` from `GET /_cluster/settings` so that, if we do register the cluster, we use the dynamic name.