### PR TITLE
[Diagnostic] Add note for CA Certificate being required

### DIFF
--- a/tools/check_connectivity.sh
+++ b/tools/check_connectivity.sh
@@ -130,6 +130,7 @@ CHECKS_FAILED=0
 CHECKS_SKIPPED=0
 CHECKS_WARNED=0
 PROXY_CONFIGURED=false
+CA_REQUIRED=false
 
 ES_CLUSTER_ID=""
 ES_CLUSTER_NAME=""
@@ -337,9 +338,12 @@ check_elasticsearch() {
 
     test_curl_exit=${test_curl_exit:-0}
 
-    # If connection succeeded without CA, warn the user
+    # If connection succeeded without CA, warn the user; otherwise flag it as required
     if [[ $test_curl_exit -eq 0 ]]; then
       ca_warning="Connection secure without provided CA file."
+    else
+      print_info "CA certificate: Required"
+      CA_REQUIRED=true
     fi
 
     ca_opts=(--cacert "${AUTOOPS_ES_CA}")
@@ -745,20 +749,30 @@ print_summary() {
   fi
   echo ""
 
+  local summary_exit=0
+
   if [[ $CHECKS_FAILED -gt 0 ]]; then
     print_error "Connectivity issues detected. AutoOps Agent will not function."
     echo ""
     echo "  Review the troubleshooting guide and address issues before running the agent:"
     echo "  https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting"
-    return 1
+    summary_exit=1
   elif [[ $CHECKS_SKIPPED -gt 0 ]]; then
     print_success "Elastic Cloud connectivity checks passed."
     print_skipped "The Elasticsearch environment was not checked."
-    return 2
+    summary_exit=2
   else
     print_success "All checks passed. The environment is ready to use AutoOps."
-    return 0
   fi
+
+  if [[ "$CA_REQUIRED" == "true" ]]; then
+    echo ""
+    echo "  A custom CA Certificate is required when running the AutoOps Agent. You must change"
+    echo "  \`otel_samples/autoops_es.yml\` to \`otel_samples/autoops_es_ssl.yml\` and specify"
+    echo "  \`AUTOOPS_ES_CA\`, or otherwise trust the CA Certificate where the AutoOps Agent runs."
+  fi
+
+  return $summary_exit
 }
 
 # ---------------------------

--- a/tools/test_check_connectivity.sh
+++ b/tools/test_check_connectivity.sh
@@ -806,6 +806,61 @@ test_elasticsearch_ca_not_found() {
   assert_output_contains "CA certificate file not found" "$output"
 }
 
+test_elasticsearch_ca_not_required() {
+  log_test "Elasticsearch - CA certificate provided but not required"
+
+  local ca_file
+  ca_file=$(mktemp)
+
+  start_path_mock_server 4 \
+    "/" 200 '{"cluster_name": "test-cluster", "cluster_uuid": "test-uuid-abcd", "version": {"number": "8.12.0"}}' \
+    "/_cluster/settings" 200 '{}' \
+    "/_license" 200 '{"license": {"status": "active", "type": "basic", "uid": "test-uid-1234"}}'
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="${MOCK_SERVER_URL}" \
+    AUTOOPS_ES_CA="${ca_file}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  stop_mock_server
+  rm -f "${ca_file}"
+
+  assert_output_contains "Connection secure without provided CA file." "$output"
+  assert_output_not_contains "CA certificate: Required" "$output"
+  assert_output_not_contains "otel_samples/autoops_es_ssl.yml" "$output"
+}
+
+test_elasticsearch_ca_required() {
+  log_test "Elasticsearch - CA certificate required"
+
+  local ca_file
+  ca_file=$(mktemp)
+
+  local output
+  local exit_code=0
+
+  output=$(
+    ELASTIC_CLOUD_CONNECTED_MODE_API_URL="http://127.0.0.1:1" \
+    AUTOOPS_OTEL_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_URL="http://127.0.0.1:1" \
+    AUTOOPS_ES_CA="${ca_file}" \
+    bash "$CHECK_SCRIPT" 2>&1
+  ) || exit_code=$?
+
+  rm -f "${ca_file}"
+
+  assert_exit_code 1 "$exit_code"
+  assert_output_contains "CA certificate: Required" "$output"
+  assert_output_contains "otel_samples/autoops_es_ssl.yml" "$output"
+  assert_output_contains "AUTOOPS_ES_CA" "$output"
+}
+
 test_elasticsearch_version_too_old() {
   log_test "Elasticsearch - version below minimum 7.17.0"
 
@@ -1386,6 +1441,8 @@ run_all_tests() {
   test_elasticsearch_auth_failure_401
   test_elasticsearch_auth_failure_403
   test_elasticsearch_ca_not_found
+  test_elasticsearch_ca_not_required
+  test_elasticsearch_ca_required
   test_elasticsearch_version_too_old
   test_elasticsearch_version_exact_minimum
   test_elasticsearch_license_inactive


### PR DESCRIPTION
If Elasticsearch requires a CA Certificate, and it is supplied to this script, then it will tell the user at the end that it must be supplied and note that we have a configuration for that purpose that can be used.

If the CA Certificate is required, then it will print out output like:

```
% AUTOOPS_ES_URL=https://localhost:9200 \
AUTOOPS_ES_USERNAME=elastic AUTOOPS_ES_PASSWORD=my_password \
AUTOOPS_ES_CA=/path/to/ca.pem \
./tools/check_connectivity.sh

========================================
  AutoOps Connectivity Check
========================================


--- Proxy Configuration ---
  ℹ️  INFO:    No proxy detected; using direct connection.

--- Elasticsearch ---
  ℹ️  INFO:    URL: https://localhost:9200
  ℹ️  INFO:    Auth: Basic elastic:**REDACTED**
  ℹ️  INFO:    CA: /path/to/ca.pem
  ℹ️  INFO:    Checking if CA certificate is required...
  ℹ️  INFO:    CA certificate: Required
  ℹ️  INFO:    Checking connectivity to https://localhost:9200/...
  ✅ SUCCESS: Connected successfully (HTTP 200)
  ℹ️  INFO:    Version: 9.3.3
  ℹ️  INFO:    Checking cluster settings at https://localhost:9200/_cluster/settings...
  ℹ️  INFO:    Cluster: my-cluster (GY1vGBBbS_KdtPs-zxq5Pg)
  ℹ️  INFO:    Checking license status at https://localhost:9200/_license...
  ✅ SUCCESS: License: active (basic: 31a53919-7bd7-4cea-9734-bcfc852a64cd)

--- Elastic Cloud Connected Mode API ---
  ℹ️  INFO:    URL: https://api.elastic-cloud.com (default)
  ℹ️  INFO:    Checking connectivity to https://api.elastic-cloud.com/api/v1/cloud-connected/clusters...
  ✅ SUCCESS: Reachable. Can register to Elastic Cloud.

--- OTel Endpoint ---
  ℹ️  INFO:    URL: https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud (default)
  ℹ️  INFO:    Checking connectivity to https://otel-auto-ops.ap-northeast-1.aws.svc.elastic.cloud/v1/logs...
  ✅ SUCCESS: Reachable. Can ship metrics to Elastic Cloud.

--- Summary ---

  Passed:  3
  Failed:  0
  Skipped: 0

  ✅ SUCCESS: All checks passed. The environment is ready to use AutoOps.

  A custom CA Certificate is required when running the AutoOps Agent. You must change
  `otel_samples/autoops_es.yml` to `otel_samples/autoops_es_ssl.yml` and specify
  `AUTOOPS_ES_CA`, or otherwise trust the CA Certificate where the AutoOps Agent runs.
```